### PR TITLE
Fix for "Inappropriate ioctl for device" error

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,9 +6,15 @@ const HEIGHT = Ref{Int}()
 const MODE = Ref{Symbol}(:default)
 
 function terminal_size(io)
-    return displaysize(stdout)
+    ws = IOCTL.ioctl(io, IOCTL.TIOCGWINSZ)
+    # width, height
+    return (Int(ws.ws_col), Int(ws.ws_row))
 end
-terminal_size() = terminal_size(stdout)
+
+function terminal_size()
+    ds = displaysize(stdout)
+    return (last(ds), first(ds))
+end
 
 terminal_size(io, coord::Int) = terminal_size(io)[coord]
 terminal_size(coord::Int) = terminal_size(stdout, coord)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,9 +6,7 @@ const HEIGHT = Ref{Int}()
 const MODE = Ref{Symbol}(:default)
 
 function terminal_size(io)
-    ws = IOCTL.ioctl(io, IOCTL.TIOCGWINSZ)
-    # width, height
-    return (Int(ws.ws_col), Int(ws.ws_row))
+    return displaysize(stdout)
 end
 terminal_size() = terminal_size(stdout)
 


### PR DESCRIPTION
Changed terminal_size method in utils.jl to use Base.displaysize method.

This fixes the "Inappropriate ioctl for device" error when running in an
interactive rep.