### PR TITLE
Changing ispaused setting during close

### DIFF
--- a/src/terminal.jl
+++ b/src/terminal.jl
@@ -51,7 +51,6 @@ end
 
 function close(t::Terminal)
     t.isclosed[] = true
-    t.ispaused[] = false
 end
 
 """

--- a/src/terminal.jl
+++ b/src/terminal.jl
@@ -51,6 +51,7 @@ end
 
 function close(t::Terminal)
     t.isclosed[] = true
+    t.ispaused[] = true
 end
 
 """


### PR DESCRIPTION
No reason to set `ispaused` to false. Instead, setting `ispaused` to true might be safer, although probably there will only be a context switch during a read or sleep.